### PR TITLE
Revert the download destination for VSCode built-in PHP snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "scripts": {
-    "snippets": "curl -o snippets/php.code-snippets https://raw.githubusercontent.com/microsoft/vscode-php/main/snippets/php.code-snippets",
+    "snippets": "curl -o snippets/php.code-snippets https://raw.githubusercontent.com/microsoft/vscode/master/extensions/php/snippets/php.code-snippets",
     "lint": "eslint src --ext ts",
     "clean": "rimraf lib",
     "watch": "webpack --watch",

--- a/snippets/README.md
+++ b/snippets/README.md
@@ -2,4 +2,4 @@
 
 ## php.code-snippets
 
-https://raw.githubusercontent.com/microsoft/vscode-php/main/snippets/php.code-snippets
+https://raw.githubusercontent.com/microsoft/vscode/master/extensions/php/snippets/php.code-snippets


### PR DESCRIPTION
I don't know why, but it seems that php snippets were put back into the VSCode extensions directory.

See: https://github.com/microsoft/vscode/pull/114921