### PR TITLE
feat: add snippets completion feature via CompletionItemProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,6 @@ $ node -e "console.log(os.homedir() + '/intelephense/licence.txt')"
 }
 ```
 
-## Snippets support
-
-It supports built-in php snippet for VSCode.
-
-To use it, you need to install [coc-snippets](https://github.com/neoclide/coc-snippets).
-
 ## Thanks
 
 - [bmewburn/vscode-intelephense](https://github.com/bmewburn/vscode-intelephense)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Plug 'yaegassy/coc-intelephense', {'do': 'yarn install --frozen-lockfile'}
 - `intelephense.enable`: Enable coc-intelephense extension, default `true`
 - `intelephense.path`: Absolute path to intelephense module. If there is no setting, the built-in module will be used. e.g. `/path/to/node_modules/intelephense`. default: ""
 - `intelephense.server.disableCompletion`: Disable completion only (server), default: `false`
+- `intelephense.client.disableSnippetsCompletion`: Disable snippets completion only (client), default: `false`
+- `intelephense.client.snippetsCompletionExclude`: Exclude specific prefix in snippet completion, e.g. `["class", "fun"]`, default: `[]`
 - `intelephense.progress.enable`: Enable progress window for indexing, If false, display with echo messages, default: `true` [DEMO](https://github.com/yaegassy/coc-intelephense/pull/2)
 
 **Same configuration as vscode-intelephense**:

--- a/package.json
+++ b/package.json
@@ -71,6 +71,16 @@
           "default": false,
           "description": "Disable completion only (server)."
         },
+        "intelephense.client.disableSnippetsCompletion": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable snippets completion only (client)."
+        },
+        "intelephense.client.snippetsCompletionExclude": {
+          "type": "array",
+          "default": [],
+          "description": "Exclude specific prefix in snippet completion"
+        },
         "intelephense.progress.enable": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -767,12 +767,6 @@
         "title": "Cancel indexing",
         "category": "Intelephense"
       }
-    ],
-    "snippets": [
-      {
-        "language": "php",
-        "path": "./snippets/php.code-snippets"
-      }
     ]
   },
   "dependencies": {

--- a/src/completion/IntelephenseSnippetsCompletion.ts
+++ b/src/completion/IntelephenseSnippetsCompletion.ts
@@ -1,0 +1,101 @@
+import {
+  CancellationToken,
+  CompletionContext,
+  CompletionItem,
+  CompletionItemKind,
+  CompletionItemProvider,
+  CompletionList,
+  ExtensionContext,
+  InsertTextFormat,
+  Position,
+  TextDocument,
+  workspace,
+} from 'coc.nvim';
+
+import path from 'path';
+import fs from 'fs';
+
+type SnippetsJsonType = {
+  [key: string]: {
+    description: string;
+    prefix: string;
+    body: string | string[];
+  };
+};
+
+export class IntelephenseSnippetsCompletionProvider implements CompletionItemProvider {
+  private _context: ExtensionContext;
+  private snippetsFilePath: string;
+  private excludeSnippetsKeys: string[];
+
+  constructor(context: ExtensionContext) {
+    this._context = context;
+    this.snippetsFilePath = path.join(this._context.extensionPath, 'snippets', 'php.code-snippets');
+    this.excludeSnippetsKeys = workspace
+      .getConfiguration('intelephense')
+      .get<string[]>('client.snippetsCompletionExclude', []);
+  }
+
+  async getSnippetsCompletionItems(snippetsFilePath: string) {
+    const snippetsCompletionList: CompletionItem[] = [];
+    if (fs.existsSync(snippetsFilePath)) {
+      const snippetsJsonText = fs.readFileSync(snippetsFilePath, 'utf8');
+      const snippetsJson: SnippetsJsonType = JSON.parse(snippetsJsonText);
+      if (snippetsJson) {
+        Object.keys(snippetsJson).map((key) => {
+          // Check exclude
+          if (this.excludeSnippetsKeys.includes(snippetsJson[key].prefix)) return;
+
+          let snippetsText: string;
+          const body = snippetsJson[key].body;
+          if (body instanceof Array) {
+            snippetsText = body.join('\n');
+          } else {
+            snippetsText = body;
+          }
+
+          // In this extention, "insertText" is handled by "resolveCompletionItem".
+          // In "provideCompletionItems", if "insertText" contains only snippets data,
+          // it will be empty when the candidate is selected.
+          snippetsCompletionList.push({
+            label: snippetsJson[key].prefix,
+            kind: CompletionItemKind.Snippet,
+            filterText: snippetsJson[key].prefix,
+            detail: snippetsJson[key].description,
+            documentation: snippetsText,
+            insertTextFormat: InsertTextFormat.Snippet,
+            // The "snippetsText" that will eventually be added to the insertText
+            // will be stored in the "data" key
+            data: snippetsText,
+          });
+        });
+      }
+    }
+
+    return snippetsCompletionList;
+  }
+
+  async provideCompletionItems(
+    document: TextDocument,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    position: Position,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    token: CancellationToken,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    context: CompletionContext
+  ): Promise<CompletionItem[] | CompletionList> {
+    const doc = workspace.getDocument(document.uri);
+    if (!doc) return [];
+
+    const completionList = this.getSnippetsCompletionItems(this.snippetsFilePath);
+
+    return completionList;
+  }
+
+  async resolveCompletionItem(item: CompletionItem): Promise<CompletionItem> {
+    if (item.kind === CompletionItemKind.Snippet) {
+      item.insertText = item.data;
+    }
+    return item;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
 
 import { existsSync } from 'fs';
 import { IntelephenseCodeActionProvider } from './actions';
+import { IntelephenseSnippetsCompletionProvider } from './completion/IntelephenseSnippetsCompletion';
 
 const LanguageID = 'php';
 const INDEXING_STARTED_NOTIFICATION = new NotificationType('indexingStarted');
@@ -30,9 +31,9 @@ let languageClient: LanguageClient;
 export async function activate(context: ExtensionContext): Promise<void> {
   extensionContext = context;
 
-  const config = workspace.getConfiguration('intelephense');
+  const extConfig = workspace.getConfiguration('intelephense');
 
-  const isEnable = config.get<boolean>('enable', true);
+  const isEnable = extConfig.get<boolean>('enable', true);
   if (!isEnable) return;
 
   const module = context.asAbsolutePath('node_modules/intelephense');
@@ -59,6 +60,19 @@ export async function activate(context: ExtensionContext): Promise<void> {
     } catch {
       // noop
     }
+  }
+
+  // Add snippets completion by "client" side
+  const isEnableClientSnippetsCompletion = extConfig.get<boolean>('client.disableSnippetsCompletion', false);
+  if (!isEnableClientSnippetsCompletion) {
+    context.subscriptions.push(
+      languages.registerCompletionItemProvider(
+        'intelephense-snippets',
+        'ISnippets',
+        ['php'],
+        new IntelephenseSnippetsCompletionProvider(context)
+      )
+    );
   }
 
   // Add code action by "client" side


### PR DESCRIPTION
In `coc-intelephense`, snippets are configured in `contributes.snippets`, and snippet completion works in conjunction with `coc-snippets`.

However, there is a problem with this, for example, if you want to disable the snippet completion provided by `coc-intelephense` itself, you cannot.

In some cases, you may want to disable it, especially if you are using your own snippets.

Switch to using `CompletionItemProvider` to provide snippets completion feature.