### PR TITLE
feat(option): add "intelephense.server.disableDefinition" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Plug 'yaegassy/coc-intelephense', {'do': 'yarn install --frozen-lockfile'}
 - `intelephense.enable`: Enable coc-intelephense extension, default `true`
 - `intelephense.path`: Path to intelephense module. ~ and $HOME, etc. can also be used. If there is no setting, the built-in module will be used. e.g. `/path/to/node_modules/intelephense`. default: ""
 - `intelephense.server.disableCompletion`: Disable completion only (server), default: `false`
+- `intelephense.server.disableDefinition`: Disable definition only (server), default: `false`
 - `intelephense.client.disableSnippetsCompletion`: Disable snippets completion only (client), default: `false`
 - `intelephense.client.snippetsCompletionExclude`: Exclude specific prefix in snippet completion, e.g. `["class", "fun"]`, default: `[]`
 - `intelephense.progress.enable`: Enable progress window for indexing, If false, display with echo messages, default: `true` [DEMO](https://github.com/yaegassy/coc-intelephense/pull/2)

--- a/package.json
+++ b/package.json
@@ -71,6 +71,11 @@
           "default": false,
           "description": "Disable completion only (server)."
         },
+        "intelephense.server.disableDefinition": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable definition only (server)."
+        },
         "intelephense.client.disableSnippetsCompletion": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
There may be cases where you want to disable the definition of intelephense when using multiple Language Server.

For example, the Language Server of `psalm` also provides definition. I also maintain an extension called `coc-psalm`.

My specific use case is simply for verification purposes, but I'll add this feature just in case.