### PR TITLE
refactor: change from disableXXXX to disabledFeatures

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
-    "coc.nvim": "0.0.81-next.14",
+    "coc.nvim": "^0.0.81-next.14",
     "esbuild": "^0.14.18",
     "eslint": "^8.8.0",
     "eslint-config-prettier": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
-    "coc.nvim": "^0.0.80",
+    "coc.nvim": "0.0.81-next.14",
     "esbuild": "^0.14.18",
     "eslint": "^8.8.0",
     "eslint-config-prettier": "^8.3.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,12 @@ import {
   HandleDiagnosticsSignature,
   LanguageClient,
   LanguageClientOptions,
+  LinesTextDocument,
   NotificationType,
   Position,
   ProvideDefinitionSignature,
   RequestType,
   ServerOptions,
-  TextDocument,
   TransportKind,
   window,
   workspace,
@@ -97,7 +97,6 @@ function createClient(context: ExtensionContext, clearCache: boolean) {
   const runtime = intelephenseConfig.get('runtime') as string | undefined;
   const memory = Math.floor(Number(intelephenseConfig.get('maxMemory')));
   const licenceKey = intelephenseConfig.get('licenceKey') as string | undefined;
-  const serverDisableDefinition = intelephenseConfig.get<boolean>('server.disableDefinition') || false;
 
   let module = intelephenseConfig.get('path') as string | undefined;
   if (module) {
@@ -150,13 +149,12 @@ function createClient(context: ExtensionContext, clearCache: boolean) {
     disabledFeatures: getLanguageClientDisabledFeatures(),
     middleware: {
       provideDefinition: async (
-        document: TextDocument,
+        document: LinesTextDocument,
         position: Position,
         token: CancellationToken,
         next: ProvideDefinitionSignature
       ) => {
-        if (serverDisableDefinition) return;
-        //@ts-ignore
+        if (getConfigServerDisableDefinition()) return;
         return await next(document, position, token);
       },
       handleDiagnostics: getConfigDiagnosticsIgnoreErrorFeature() ? handleDiagnostics : undefined,
@@ -261,6 +259,10 @@ function getLanguageClientDisabledFeatures() {
 
 function getConfigServerDisableCompletion() {
   return workspace.getConfiguration('intelephense').get<boolean>('server.disableCompletion', false);
+}
+
+function getConfigServerDisableDefinition() {
+  return workspace.getConfiguration('intelephense').get<boolean>('server.disableDefinition', false);
 }
 
 function getConfigDiagnosticsIgnoreErrorFeature() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,7 +402,7 @@ cls-hooked@^4.2.2:
     emitter-listener "^1.0.1"
     semver "^5.4.1"
 
-coc.nvim@0.0.81-next.14:
+coc.nvim@^0.0.81-next.14:
   version "0.0.81-next.14"
   resolved "https://registry.yarnpkg.com/coc.nvim/-/coc.nvim-0.0.81-next.14.tgz#3e200650a6ccdee6ac097e2ebc9e43c9f4fce3e2"
   integrity sha512-vq8M4rFTEFOLh/uIuqKnN684q/MGyPJ3UXJfovHtPj4H3i65/ob09yLHFI7W421P9JSAHNUw9Ic5cjmriEOcyg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,10 +402,10 @@ cls-hooked@^4.2.2:
     emitter-listener "^1.0.1"
     semver "^5.4.1"
 
-coc.nvim@^0.0.80:
-  version "0.0.80"
-  resolved "https://registry.yarnpkg.com/coc.nvim/-/coc.nvim-0.0.80.tgz#785145c382660db03f517f9b497900d95cbd0e4f"
-  integrity sha512-/3vTcnofoAYMrdENrlQmADTzfXX4+PZ0fiM10a39UA37dTR2dpIGi9O469kcIksuunLjToqWG8S45AGx/9wV7g==
+coc.nvim@0.0.81-next.14:
+  version "0.0.81-next.14"
+  resolved "https://registry.yarnpkg.com/coc.nvim/-/coc.nvim-0.0.81-next.14.tgz#3e200650a6ccdee6ac097e2ebc9e43c9f4fce3e2"
+  integrity sha512-vq8M4rFTEFOLh/uIuqKnN684q/MGyPJ3UXJfovHtPj4H3i65/ob09yLHFI7W421P9JSAHNUw9Ic5cjmriEOcyg==
 
 color-convert@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Description
-------------------------------------------------------

In this commit of coc.nvim, `disableCompletion` etc. have been removed and `disabledFeatures` has been added.

- <https://github.com/neoclide/coc.nvim/commit/a60702d0b0da710cfa261c0970ff51f34d0fef0b>

This is a feature change that also affects the `LanguageClientOptions` in the coc extension.

I told chemzqm that there might be a problem, and he was able to adjust it.

- <https://github.com/neoclide/coc.nvim/commit/c610d4c69e1e11ce80f8770235c85304f7277178>

However, `:CocInfo` will output a WARN message. This `WARN` message has no adverse effect on the feature itself.

```
2022-02-04T16:02:53.420 WARN (pid:24998) [language-client-client] - disableCompletion in the client options is deprecated. use disabledFeatures instead. 
```

Change
-------------------------------------------------------

Since `disableCompletion` and others have been deprecated, refactor to move to `disabledFeatures`.

