### PR TITLE
feat: add "autoCloseDocCommentDoSugesst" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ $ node -e "console.log(os.homedir() + '/intelephense/licence.txt')"
 - `intelephense.client.diagnosticsIgnoreErrorFeature`: Whether to enable the PHPDoc tag (`// @intelephense-ignore-line`, `/** @intelephense-ignore-next-line */`) feature and ignore errors, default: `false` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/16)
   - This feature is a proprietary implementation of `coc-intelephense`. This feature will be removed when the dedicated feature is added in the upstream's `vscode-intelephense` or `intelephense` language server.
   - I made it an ignore comment like `phpstan`, Please refer to this page for usage. <https://phpstan.org/user-guide/ignoring-errors#ignoring-in-code-using-phpdocs>
+- `intelephense.client.autoCloseDocCommentDoSugesst`: When `/**` is entered, `*/` is automatically inserted (`/**| */`). Then, continue, automatically triggers completion of PHPDoc comments, default: `true`
 - `intelephense.client.disableSnippetsCompletion`: Disable snippets completion only (client), default: `false`
 - `intelephense.client.snippetsCompletionExclude`: Exclude specific prefix in snippet completion, e.g. `["class", "fun"]`, default: `[]`
 - `intelephense.server.disableCompletion`: Disable completion only (server), default: `false`

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ node -e "console.log(os.homedir() + '/intelephense/licence.txt')"
 - `intelephense.client.diagnosticsIgnoreErrorFeature`: Whether to enable the PHPDoc tag (`// @intelephense-ignore-line`, `/** @intelephense-ignore-next-line */`) feature and ignore errors, default: `false` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/16)
   - This feature is a proprietary implementation of `coc-intelephense`. This feature will be removed when the dedicated feature is added in the upstream's `vscode-intelephense` or `intelephense` language server.
   - I made it an ignore comment like `phpstan`, Please refer to this page for usage. <https://phpstan.org/user-guide/ignoring-errors#ignoring-in-code-using-phpdocs>
-- `intelephense.client.autoCloseDocCommentDoSugesst`: When `/**` is entered, `*/` is automatically inserted (`/**| */`). Then, continue, automatically triggers completion of PHPDoc comments, default: `true`
+- `intelephense.client.autoCloseDocCommentDoSugesst`: When `/**` is entered, `*/` is automatically inserted (`/**| */`). Then, continue, automatically triggers completion of PHPDoc comments, default: `true` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/24#issuecomment-1088219510)
 - `intelephense.client.disableSnippetsCompletion`: Disable snippets completion only (client), default: `false`
 - `intelephense.client.snippetsCompletionExclude`: Exclude specific prefix in snippet completion, e.g. `["class", "fun"]`, default: `[]`
 - `intelephense.server.disableCompletion`: Disable completion only (server), default: `false`

--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
           "default": false,
           "description": "Whether to enable the PHPDoc tag (`@intelephense-ignore-line`, `@intelephense-ignore-next-line`) feature and ignore errors."
         },
+        "intelephense.client.autoCloseDocCommentDoSugesst": {
+          "type": "boolean",
+          "default": true,
+          "description": "When `/**` is entered, `*/` is automatically inserted (`/**| */`). Then, continue, automatically triggers completion of PHPDoc comments."
+        },
         "intelephense.client.disableSnippetsCompletion": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
## Description

"intelephense" will suggest the completion item `/** [Intelephense PHPDoc] */` in the case of `/**| */`.

In `vscode-intelephense`, `*/` is automatically inserted in the "Language Configuration" function of the VSCode itself. <https://code.visualstudio.com/api/language-extensions/language-configuration-guide>

This is not a problem with `vscode-intelephense`, but it is a problem when used from Vim. Completion items are also suggested in the following cases, but there is a glitch.

**Before**:

> `|` is the cursor.

```php
    /**|
    public function dummy1()
    {
      // ...snip
    }

    /**
     *
     */
    public function dummy2()
    {
      // ...snip
    }
```

**After**:

This is a bug that causes the dummy2 method to disappear... :(

```php
    /**
     * 
     * @return void 
     */
    public function dummy1()
    {
        //
    }
```

## Add feature

Added the ability to behave as follows.

1. Auto insert `*/` by typing `/**`.
2. Text will be `/**| */`. (`|` is the cursor)
3. Automatically triggers completion at the current cursor position.
4. `/** [Intelephense PHPDoc] */` complemention items are suggested.

If this feature is not needed, it can be disabled. Set `intelephense.client.autoCloseDocCommentDoSugesst` to `false`.

