### PR TITLE
feat: add Laravel Artisan integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ $ node -e "console.log(os.homedir() + '/intelephense/licence.txt')"
 - `intelephense.phpunit.path`: Path to phpunit command. If there is no setting, the vendor/bin/phpunit will be used, default: `""`
 - `intelephense.phpunit.colors`: Use colors in output (--colors), default: `false`
 - `intelephense.phpunit.debug`: Display debugging information (--debug), default: `false`
+- `intelephense.artisan.enableSplitRight`: Use vertical belowright for artisan terminal window, default: `false`
 - `intelephense.progress.enable`: Enable progress window for indexing, If false, display with echo messages, default: `true` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/2)
 
 **Same configuration as vscode-intelephense**:
@@ -137,6 +138,7 @@ $ node -e "console.log(os.homedir() + '/intelephense/licence.txt')"
 - `intelephense.phpunit.projectTest`: Run PHPUnit for current project
 - `intelephense.phpunit.fileTest`: Run PHPUnit for current file
 - `intelephense.phpunit.singleTest`: Run PHPUnit for single (nearest) test
+- `intelephense.artisan.runCommand`: Run Artisan command
 
 **Example of Vim command and key mapping**:
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ $ node -e "console.log(os.homedir() + '/intelephense/licence.txt')"
 - `intelephense.phpunit.projectTest`: Run PHPUnit for current project
 - `intelephense.phpunit.fileTest`: Run PHPUnit for current file
 - `intelephense.phpunit.singleTest`: Run PHPUnit for single (nearest) test
-- `intelephense.artisan.runCommand`: Run Artisan command
+- `intelephense.artisan.runCommand`: Run Artisan command | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/25)
 
 **Example of Vim command and key mapping**:
 

--- a/package.json
+++ b/package.json
@@ -154,6 +154,11 @@
           "default": false,
           "description": "Display debugging information (--debug)."
         },
+        "intelephense.artisan.enableSplitRight": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use vertical belowright for artisan terminal window."
+        },
         "intelephense.progress.enable": {
           "type": "boolean",
           "default": true,
@@ -878,6 +883,11 @@
       {
         "command": "intelephense.phpunit.singleTest",
         "title": "Run PHPUnit for single (nearest) test",
+        "category": "Intelephense"
+      },
+      {
+        "command": "intelephense.artisan.runCommand",
+        "title": "Run Artisan command",
         "category": "Intelephense"
       }
     ]

--- a/src/commands/artisan.ts
+++ b/src/commands/artisan.ts
@@ -1,0 +1,142 @@
+import {
+  BasicList,
+  commands,
+  ExtensionContext,
+  ListAction,
+  ListContext,
+  ListItem,
+  Neovim,
+  Terminal,
+  window,
+  workspace,
+  listManager,
+} from 'coc.nvim';
+
+import cp from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+let terminal: Terminal | undefined;
+
+type ArtisanListJsonType = {
+  application: {
+    name: string;
+    version: string;
+  };
+  commands: ArtisanListCommandsJsonType[];
+  namespaces: {
+    id: string;
+    commands: string[];
+  };
+};
+
+type ArtisanListCommandsJsonType = {
+  name: string;
+  description: string;
+};
+
+export function activate(context: ExtensionContext) {
+  listManager.registerList(new ArtisanList(workspace.nvim));
+
+  context.subscriptions.push(
+    commands.registerCommand('intelephense.artisan.runCommand', () => {
+      workspace.nvim.command(`CocList artisan`);
+    })
+  );
+}
+
+async function getArtisanPath() {
+  let cmdPath = '';
+  const artisanPath = path.join(workspace.root, 'artisan');
+  if (fs.existsSync(artisanPath)) {
+    cmdPath = artisanPath;
+  }
+  return cmdPath;
+}
+
+async function getArtisanListCommandsJson(artisanPath: string) {
+  return new Promise<string[]>((resolve) => {
+    cp.exec(`${artisanPath} list --format json`, (err, stdout, stderr) => {
+      if (err || stderr) resolve([]);
+
+      if (stdout.length > 0) {
+        try {
+          const artisanListJson = JSON.parse(stdout) as ArtisanListJsonType;
+          const names = artisanListJson.commands.map((c) => c.name);
+          resolve(names);
+        } catch (e) {
+          resolve([]);
+        }
+      } else {
+        resolve([]);
+      }
+    });
+  });
+}
+
+async function runArtisan(commandName: string) {
+  const artisanPath = await getArtisanPath();
+  if (!artisanPath) {
+    window.showErrorMessage(`artisan command not found!`);
+    return;
+  }
+
+  let input = '';
+  const isInput = await window.showPrompt(`"${commandName}" | Add args & options?`);
+  if (isInput) {
+    input = await window.requestInput(`${commandName}`);
+    if (!input) {
+      const isExec = await window.showPrompt(`Input is empty, can I run it?`);
+      if (!isExec) return;
+    }
+  }
+
+  const args: string[] = [];
+  args.push(artisanPath);
+  args.push(commandName);
+  if (input) args.push(input);
+
+  if (terminal) {
+    if (terminal.bufnr) {
+      await workspace.nvim.command(`bd! ${terminal.bufnr}`);
+    }
+    terminal.dispose();
+    terminal = undefined;
+  }
+
+  terminal = await window.createTerminal({ name: 'artisan', cwd: workspace.root });
+  terminal.sendText(`php ${args.join(' ')}`);
+
+  const enableSplitRight = workspace.getConfiguration('intelephense').get('artisan.enableSplitRight', false);
+
+  if (enableSplitRight) terminal.hide();
+  await workspace.nvim.command('stopinsert');
+  if (enableSplitRight) await workspace.nvim.command(`vert bel sb ${terminal.bufnr}`);
+}
+
+export class ArtisanList extends BasicList {
+  public readonly name = 'artisan';
+  public readonly description = 'artisan for coc-intelephense';
+  public readonly defaultAction = 'execute';
+  public actions: ListAction[] = [];
+
+  constructor(nvim: Neovim) {
+    super(nvim);
+
+    this.addAction('execute', (item: ListItem) => {
+      runArtisan(item.label);
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public async loadItems(context: ListContext): Promise<ListItem[]> {
+    const listItems: ListItem[] = [];
+    const artisanPath = await getArtisanPath();
+    if (!artisanPath) {
+      return listItems;
+    }
+    const commands = await getArtisanListCommandsJson(artisanPath);
+    commands.forEach((c) => listItems.push({ label: c }));
+    return listItems;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,8 @@ import { fileTestCommand, projectTestCommand, singleTestCommand } from './comman
 import { IntelephenseSnippetsCompletionProvider } from './completion/IntelephenseSnippetsCompletion';
 import { IntelephenseCodeLensProvider } from './lenses';
 
+import * as artisan from './commands/artisan';
+
 const PHP_LANGUAGE_ID = 'php';
 const INDEXING_STARTED_NOTIFICATION = new NotificationType('indexingStarted');
 const INDEXING_ENDED_NOTIFICATION = new NotificationType('indexingEnded');
@@ -106,6 +108,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
     commands.registerCommand('intelephense.composer.runCommandPlus', runCommandPlusCommand()),
     commands.registerCommand('intelephense.composer.runScriptsCommand', runScriptsCommand())
   );
+
+  artisan.activate(context);
 
   // Add code lens by "client" side
   if (!getConfigPhpUnitDisableCodeLens()) {


### PR DESCRIPTION
## Description

Added `artisan` command integration features.

### Commands

- `intelephense.artisan.runCommand`: Run Artisan command

### Settings(coc-settings.json)

- `intelephense.artisan.enableSplitRight`: Use vertical belowright for artisan terminal window, default: `false`

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/161935877-dec11ae3-a4ff-4bbe-86c8-5d81c981182d.mp4

---

> "intelephense.artisan.enableSplitRight": true

https://user-images.githubusercontent.com/188642/161935920-0437dd79-b1a4-4238-ac00-9b4fd4ccd048.mp4
