### PR TITLE
feat: Integration of Pest command and CodeLens

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,16 @@ $ node -e "console.log(os.homedir() + '/intelephense/licence.txt')"
 - `intelephense.composer.runCommandList`: Set the subcommand of the composer you want to execute, default: `["dump-autoload", "clear-cache", "install", "update"]`
 - `intelephense.composer.runCommandPlusList`: Set the subcommand of the composer you want to execute. Additional strings can be entered and executed in the subcommand. default: `["require", "require --dev", "remove", "remove --dev", "update"]`
 - `intelephense.composer.enableSplitRight`: Use vertical belowright for composer terminal window, default: `false`
+- `intelephense.artisan.enableSplitRight`: Use vertical belowright for artisan terminal window, default: `false`
 - `intelephense.phpunit.path`: Path to phpunit command. If there is no setting, the vendor/bin/phpunit will be used, default: `""`
 - `intelephense.phpunit.colors`: Use colors in output (--colors), default: `false`
 - `intelephense.phpunit.debug`: Display debugging information (--debug), default: `false`
 - `intelephense.phpunit.codeLensTitle`: CodeLens title. Can be changed to any display, default: `">> [Run PHPUnit]"`
 - `intelephense.phpunit.enableSplitRight`: Use vertical belowright for phpunit terminal window, default: `false`
-- `intelephense.artisan.enableSplitRight`: Use vertical belowright for artisan terminal window, default: `false`
+- `intelephense.pest.path`: Path to Pest command. If there is no setting, the vendor/bin/pest will be used, default: `""`
+- `intelephense.pest.doNotCacheResult`: Do not write test results to cache file (--do-not-cache-result), default: `true`
+- `intelephense.pest.codeLensTitle`: CodeLens title. Can be changed to any display, default: `">> [Run Pest]"`
+- `intelephense.pest.enableSplitRight`: Use vertical belowright for pest terminal window, default: `false`
 - `intelephense.progress.enable`: Enable progress window for indexing, If false, display with echo messages, default: `true` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/2)
 
 **Same configuration as vscode-intelephense**:
@@ -138,16 +142,22 @@ $ node -e "console.log(os.homedir() + '/intelephense/licence.txt')"
 - `intelephense.composer.runScriptsCommand`: Run selected composer script
   - Select and run the script defined in the "scripts section" of `composer.json`. The `pre-...` and `post-...` event scripts are excluded from the list.
   - [DEMO](https://github.com/yaegassy/coc-intelephense/pull/23#issuecomment-1085414532)
+- `intelephense.artisan.runCommand`: Run Artisan command | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/25)
 - `intelephense.phpunit.projectTest`: Run PHPUnit for current project
 - `intelephense.phpunit.fileTest`: Run PHPUnit for current file
 - `intelephense.phpunit.singleTest`: Run PHPUnit for single (nearest) test
-- `intelephense.artisan.runCommand`: Run Artisan command | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/25)
+- `intelephense.pest.projectTest`: Run Pest for current project
+- `intelephense.pest.fileTest`: Run Pest for current file
+- `intelephense.pest.singleTest`: Run Pest for single (nearest) test
 
 **Example of Vim command and key mapping**:
 
 Vim commands can be defined and executed or key mappings can be set and used.
 
 ```vim
+" Quickly view a list of all coc.nvim commands
+nnoremap <silent> <C-p> :<C-u>CocCommand<CR>
+
 " Run PHPUnit for current project
 command! -nargs=0 PHPUnit :call CocAction('runCommand', 'intelephense.phpunit.projectTest')
 
@@ -188,7 +198,7 @@ nmap <silent> gl <Plug>(coc-codelens-action)
 
 "CodeLens" does not work with "Vim8" due to coc.nvim specifications.
 
-`intelephense.phpunit.singleTest` commands are available, so please use them.
+`intelephense.phpunit.singleTest` command and `intelephense.pest.singleTest` command are available, so please use them.
 
 ## Code Actions
 

--- a/package.json
+++ b/package.json
@@ -148,6 +148,11 @@
           "default": false,
           "description": "Use vertical belowright for composer terminal window."
         },
+        "intelephense.artisan.enableSplitRight": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use vertical belowright for artisan terminal window."
+        },
         "intelephense.phpunit.path": {
           "type": "string",
           "default": "",
@@ -173,10 +178,25 @@
           "default": false,
           "description": "Use vertical belowright for phpunit terminal window."
         },
-        "intelephense.artisan.enableSplitRight": {
+        "intelephense.pest.path": {
+          "type": "string",
+          "default": "",
+          "description": "Path to Pest command. If there is no setting, the vendor/bin/pest will be used."
+        },
+        "intelephense.pest.doNotCacheResult": {
+          "type": "boolean",
+          "default": true,
+          "description": "Do not write test results to cache file (--do-not-cache-result)."
+        },
+        "intelephense.pest.codeLensTitle": {
+          "type": "string",
+          "default": ">> [Run Pest]",
+          "description": "CodeLens title. Can be changed to any display."
+        },
+        "intelephense.pest.enableSplitRight": {
           "type": "boolean",
           "default": false,
-          "description": "Use vertical belowright for artisan terminal window."
+          "description": "Use vertical belowright for pest terminal window."
         },
         "intelephense.progress.enable": {
           "type": "boolean",
@@ -890,6 +910,11 @@
         "category": "Intelephense"
       },
       {
+        "command": "intelephense.artisan.runCommand",
+        "title": "Run Artisan command",
+        "category": "Intelephense"
+      },
+      {
         "command": "intelephense.phpunit.projectTest",
         "title": "Run PHPUnit for current project",
         "category": "Intelephense"
@@ -905,8 +930,18 @@
         "category": "Intelephense"
       },
       {
-        "command": "intelephense.artisan.runCommand",
-        "title": "Run Artisan command",
+        "command": "intelephense.pest.projectTest",
+        "title": "Run Pest for current project",
+        "category": "Intelephense"
+      },
+      {
+        "command": "intelephense.pest.fileTest",
+        "title": "Run Pest for current file",
+        "category": "Intelephense"
+      },
+      {
+        "command": "intelephense.pest.singleTest",
+        "title": "Run Pest for single (nearest) test",
         "category": "Intelephense"
       }
     ]

--- a/src/commands/pest.ts
+++ b/src/commands/pest.ts
@@ -1,0 +1,127 @@
+import { commands, ExtensionContext, Terminal, Uri, window, workspace } from 'coc.nvim';
+
+import path from 'path';
+import fs from 'fs';
+import { getPestTestData, getMethods, getTestName, getTestNameByPestTestData } from '../parsers';
+
+let terminal: Terminal | undefined;
+
+export function activate(context: ExtensionContext) {
+  context.subscriptions.push(
+    commands.registerCommand('intelephense.pest.projectTest', pestProjectTestCommand()),
+    commands.registerCommand('intelephense.pest.fileTest', pestFileTestCommand()),
+    commands.registerCommand('intelephense.pest.singleTest', pestSingleTestCommand())
+  );
+}
+
+function getPestPath() {
+  let cmdPath = '';
+  const pestPath = workspace.getConfiguration('intelephense').get<string>('pest.path');
+  const vendorPestPath = path.join(workspace.root, 'vendor', 'bin', 'pest');
+
+  if (pestPath && fs.existsSync(pestPath)) {
+    cmdPath = pestPath;
+  } else if (fs.existsSync(vendorPestPath)) {
+    cmdPath = path.join(workspace.root, 'vendor', 'bin', 'pest');
+  }
+
+  return cmdPath;
+}
+
+async function runPest(filePath?: string, testName?: string) {
+  const pestBin = getPestPath();
+  const pestDoNotCacheResult = workspace.getConfiguration('intelephense').get<boolean>('pest.doNotCacheResult', true);
+
+  if (pestBin) {
+    if (terminal) {
+      if (terminal.bufnr) {
+        await workspace.nvim.command(`bd! ${terminal.bufnr}`);
+      }
+      terminal.dispose();
+      terminal = undefined;
+    }
+
+    terminal = await window.createTerminal({ name: 'pest', cwd: workspace.root });
+
+    const args: string[] = [];
+    if (pestDoNotCacheResult) args.push('--do-not-cache-result');
+
+    if (testName && filePath) {
+      args.push('--filter');
+      args.push(`'::${testName}$'`);
+      args.push(`${filePath}`);
+      terminal.sendText(`${pestBin} ${args.join(' ')}`);
+    } else if (filePath) {
+      args.push(`${filePath}`);
+      terminal.sendText(`${pestBin} ${args.join(' ')}`);
+    } else {
+      if (args.length > 0) {
+        terminal.sendText(`${pestBin} ${args.join(' ')}`);
+      } else {
+        terminal.sendText(`${pestBin}`);
+      }
+    }
+
+    const enableSplitRight = workspace.getConfiguration('intelephense').get('pest.enableSplitRight', false);
+
+    if (enableSplitRight) terminal.hide();
+    await workspace.nvim.command('stopinsert');
+    if (enableSplitRight) await workspace.nvim.command(`vert bel sb ${terminal.bufnr}`);
+  } else {
+    return window.showErrorMessage('pest not found!');
+  }
+}
+
+export function pestProjectTestCommand() {
+  return async () => {
+    const { document } = await workspace.getCurrentState();
+    const filePath = Uri.parse(document.uri).fsPath;
+
+    if (document.languageId !== 'php' || !filePath.endsWith('Test.php')) {
+      return window.showErrorMessage('This file is not a PHP test file!');
+    }
+
+    runPest();
+  };
+}
+
+export function pestFileTestCommand() {
+  return async () => {
+    const { document } = await workspace.getCurrentState();
+    const filePath = Uri.parse(document.uri).fsPath;
+
+    if (document.languageId !== 'php' || !filePath.endsWith('Test.php')) {
+      return window.showErrorMessage('This file is not a PHP test file!');
+    }
+
+    runPest(filePath);
+  };
+}
+
+export function pestSingleTestCommand() {
+  return async () => {
+    const { document, position } = await workspace.getCurrentState();
+    const filePath = Uri.parse(document.uri).fsPath;
+
+    if (document.languageId !== 'php' || !filePath.endsWith('Test.php')) {
+      return window.showErrorMessage('This file is not a PHP test file!');
+    }
+
+    let testName = '';
+    const pestTestData = await getPestTestData(document);
+    const pestTestName = getTestNameByPestTestData(pestTestData, position);
+    if (pestTestName) {
+      testName = pestTestName;
+    } else {
+      const methods = await getMethods(document);
+      const methodTestName = getTestName(methods, position);
+      if (methodTestName) testName = methodTestName;
+    }
+
+    if (testName) {
+      runPest(filePath, testName);
+    } else {
+      window.showErrorMessage(`Test not found`);
+    }
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,15 +20,15 @@ import {
   window,
   workspace,
 } from 'coc.nvim';
-
 import { existsSync } from 'fs';
 import { IntelephenseCodeActionProvider } from './actions';
-import { IntelephenseSnippetsCompletionProvider } from './completion/IntelephenseSnippetsCompletion';
-import { PHPUnitCodeLensProvider } from './lens/PHPUnitCodeLensProvider';
-
-import * as composer from './commands/composer';
-import * as phpunit from './commands/phpunit';
 import * as artisan from './commands/artisan';
+import * as composer from './commands/composer';
+import * as pest from './commands/pest';
+import * as phpunit from './commands/phpunit';
+import { IntelephenseSnippetsCompletionProvider } from './completion/IntelephenseSnippetsCompletion';
+import { PestCodeLensProvider } from './lens/PestCodeLensProvider';
+import { PHPUnitCodeLensProvider } from './lens/PHPUnitCodeLensProvider';
 
 const PHP_LANGUAGE_ID = 'php';
 const INDEXING_STARTED_NOTIFICATION = new NotificationType('indexingStarted');
@@ -101,19 +101,24 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   // Add commands by "client" side
   composer.activate(context);
-  phpunit.activate(context);
   artisan.activate(context);
+  phpunit.activate(context);
+  pest.activate(context);
 
   // Add code lens by "client" side
   if (!getConfigDisableCodeLens()) {
     const useCodelensProvider = getConfigCodelensProvider();
-
     if (useCodelensProvider === 'phpunit') {
       context.subscriptions.push(
         languages.registerCodeLensProvider(
           [{ language: PHP_LANGUAGE_ID, scheme: 'file' }],
           new PHPUnitCodeLensProvider()
         )
+      );
+    }
+    if (useCodelensProvider === 'pest') {
+      context.subscriptions.push(
+        languages.registerCodeLensProvider([{ language: PHP_LANGUAGE_ID, scheme: 'file' }], new PestCodeLensProvider())
       );
     }
   }

--- a/src/lens/PestCodeLensProvider.ts
+++ b/src/lens/PestCodeLensProvider.ts
@@ -1,0 +1,83 @@
+import {
+  CancellationToken,
+  CodeLens,
+  CodeLensProvider,
+  events,
+  LinesTextDocument,
+  Position,
+  Range,
+  Uri,
+  workspace,
+} from 'coc.nvim';
+import { getMethods, getPestTestData, getTestMethods } from '../parsers';
+
+export class PestCodeLensProvider implements CodeLensProvider {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async provideCodeLenses(document: LinesTextDocument, token: CancellationToken) {
+    const filePath = Uri.parse(document.uri).fsPath;
+
+    if (document.languageId !== 'php' || !filePath.endsWith('Test.php')) {
+      return [];
+    }
+
+    const codeLensTitle = workspace.getConfiguration('intelephense').get('pest.codeLensTitle', '>> [RUN Pest]');
+    const codeLenses: CodeLens[] = [];
+
+    // do not process codelens when in insert mode
+    if (events.insertMode) return codeLenses;
+
+    try {
+      const methods = await getMethods(document);
+      const testMethods = getTestMethods(methods);
+
+      testMethods.forEach((m) => {
+        if (m.startLine && m.endLine) {
+          const lens: CodeLens = {
+            range: Range.create(Position.create(m.startLine - 1, 0), Position.create(m.endLine, 0)),
+            command: {
+              title: codeLensTitle,
+              command: 'intelephense.pest.singleTest',
+            },
+          };
+
+          codeLenses.push(lens);
+        }
+      });
+    } catch (e) {
+      // noop
+    }
+
+    try {
+      const pestTestData = await getPestTestData(document);
+
+      pestTestData.forEach((m) => {
+        if (m.startLine && m.endLine) {
+          const lens: CodeLens = {
+            range: Range.create(Position.create(m.startLine - 1, 0), Position.create(m.endLine, 0)),
+            command: {
+              title: codeLensTitle,
+              command: 'intelephense.pest.singleTest',
+            },
+          };
+
+          codeLenses.push(lens);
+        }
+      });
+    } catch (e) {
+      // noop
+    }
+
+    // For some reason, the virtual text does not disappear even when the
+    // number of code lens goes from 1 to 0.
+    //
+    // It may be a bug in coc.nvim itself, but it sends code lens with Range
+    // of 0 and forces a refresh.
+    if (codeLenses.length === 0) {
+      codeLenses.push({
+        range: Range.create(Position.create(0, 0), Position.create(0, 0)),
+      });
+    }
+
+    return codeLenses;
+  }
+}


### PR DESCRIPTION
## Description

Added integration capabilities for Pest, a testing framework for PHP. Pest is similar to Jest.

- <https://pestphp.com/>
- <https://github.com/pestphp/pest>

## Commands

- `intelephense.pest.projectTest`: Run Pest for current project
- `intelephense.pest.fileTest`: Run Pest for current file
- `intelephense.pest.singleTest`: Run Pest for single (nearest) test

## Settings(coc-settings.json)

- `intelephense.pest.path`: Path to Pest command. If there is no setting, the vendor/bin/pest will be used, default: `""`
- `intelephense.pest.doNotCacheResult`: Do not write test results to cache file (--do-not-cache-result), default: `true`
- `intelephense.pest.codeLensTitle`: CodeLens title. Can be changed to any display, default: `">> [Run Pest]"`
- `intelephense.pest.enableSplitRight`: Use vertical belowright for pest terminal window, default: `false`

## CodeLens

Set `intelephense.client.codelensProvider` to `pest`. The default is `phpunit`.