### PR TITLE
feat: cancellation support for progress notification

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -286,6 +286,7 @@ function indexWorkspace() {
 
 function cancelIndexing() {
   languageClient.sendRequest(CANCEL_INDEXING_REQUEST.method);
+  window.showWarningMessage('intelephense indexing has been canceled!');
 }
 
 // MEMO: support progress window for indexing
@@ -326,14 +327,20 @@ function registerNotificationListeners() {
   }
 }
 
-// MEMO: support progress window for indexing
 async function displayInitIndexProgress<T = void>(promise: Promise<T>) {
   return window.withProgress(
     {
       title: 'intelephense indexing ...',
       cancellable: true,
     },
-    () => promise
+    (progress, token) => {
+      // mouse option is required to cancel
+      // e.g. :set mouse=n
+      token.onCancellationRequested(() => {
+        cancelIndexing();
+      });
+      return promise;
+    }
   );
 }
 


### PR DESCRIPTION
VSCode like notifications are now supported in coc.nvim. <https://github.com/neoclide/coc.nvim/discussions/3813>

coc-intelephense uses progress notification for language server indexing. Added feature when clicking "Cancel".

The `mouse` option is required to cancel. In init.vim, add `set mouse=n`. Also, this feature is only supported by neovim.

**DEMO (mp4)**:

https://user-images.githubusercontent.com/188642/168406302-3289b6de-19a7-4ed3-a7a8-b995c09492dd.mp4
