### PR TITLE
feat(codeaction): Change Visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ nmap <silent> gA <Plug>(coc-codeaction)
 - `Insert PHP Getter` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/33#issuecomment-1140683583)
 - `Insert PHP Setter` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/33#issuecomment-1140684502)
 - `Insert PHP Getter & Setter` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/33#issuecomment-1140685034)
-- `Change Visibility`
+- `Change Visibility` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/37#issue-1259334586)
 
 **Code Actions (Server side)**:
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ nmap <silent> gA <Plug>(coc-codeaction)
 - `Insert PHP Getter` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/33#issuecomment-1140683583)
 - `Insert PHP Setter` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/33#issuecomment-1140684502)
 - `Insert PHP Getter & Setter` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/33#issuecomment-1140685034)
+- `Change Visibility`
 
 **Code Actions (Server side)**:
 

--- a/src/actions/changeVisibility.ts
+++ b/src/actions/changeVisibility.ts
@@ -1,0 +1,78 @@
+import {
+  CodeAction,
+  CodeActionProvider,
+  commands,
+  Document,
+  DocumentSelector,
+  ExtensionContext,
+  languages,
+  Range,
+  TextDocument,
+  TextEdit,
+  window,
+  workspace,
+} from 'coc.nvim';
+
+export function activate(context: ExtensionContext) {
+  const documentSelector: DocumentSelector = [{ language: 'php', scheme: 'file' }];
+
+  context.subscriptions.push(
+    languages.registerCodeActionProvider(documentSelector, new ChangeVisibilityCodeActionProvider(), 'intelephense')
+  );
+
+  // internal command
+  context.subscriptions.push(
+    commands.registerCommand('intelephense.runChangeVisibility', runChangeVisibilityCommand(), null, true)
+  );
+}
+
+function runChangeVisibilityCommand() {
+  return async (doc: Document, wordRange: Range, text: string) => {
+    const visibilities = ['public', 'protected', 'private'];
+    const changeVisibilities = visibilities.filter((v) => v !== text);
+
+    const picked = await window.showMenuPicker(changeVisibilities, `Select (from ${text})`);
+
+    if (picked !== -1) {
+      const edits = [TextEdit.replace(wordRange, changeVisibilities[picked])];
+      await doc.applyEdits(edits);
+    }
+  };
+}
+
+class ChangeVisibilityCodeActionProvider implements CodeActionProvider {
+  public async provideCodeActions(document: TextDocument, range: Range) {
+    const codeActions: CodeAction[] = [];
+    const doc = workspace.getDocument(document.uri);
+
+    if (this.cursorRange(range)) {
+      const cursorPosition = await window.getCursorPosition();
+
+      const wordRange = doc.getWordRangeAtPosition(cursorPosition);
+      if (!wordRange) return [];
+
+      const text = document.getText(wordRange) || '';
+      if (!text) return [];
+
+      if (!['public', 'protected', 'private'].includes(text)) return [];
+
+      const actionCommand = {
+        title: '',
+        command: 'intelephense.runChangeVisibility',
+        arguments: [doc, wordRange, text],
+      };
+
+      const codeAction: CodeAction = {
+        title: 'Change Visibility',
+        command: actionCommand,
+      };
+      codeActions.push(codeAction);
+    }
+
+    return codeActions;
+  }
+
+  private cursorRange(range: Range) {
+    return range.start.line === range.end.line && range.start.character === range.end.character;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   workspace,
 } from 'coc.nvim';
 import fs from 'fs';
+import * as changeVisibilityCodeActionFeature from './actions/changeVisibility';
 import * as getterSetterCodeActionFeature from './actions/getterSetter';
 import * as ignoreCommentCodeActionFeature from './actions/ignoreComment';
 import * as openPHPNetCodeActionFeature from './actions/openPHPNet';
@@ -105,6 +106,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   pestCodeLensFeature.activate(context);
 
   // Add code action by "client" side
+  changeVisibilityCodeActionFeature.activate(context);
   openPHPNetCodeActionFeature.activate(context);
   ignoreCommentCodeActionFeature.activate(context);
   getterSetterCodeActionFeature.activate(context);


### PR DESCRIPTION
## DEMO (mp4)

### Change Visibility

Works with `<Plug>(coc-codeaction-cursor)`

**Example key mapping**:

```vim
nmap <silent> <leader>a <Plug>(coc-codeaction-cursor)
```

https://user-images.githubusercontent.com/188642/171780236-cc2eafa5-9595-4296-85a6-0318ab979022.mp4
