### PR TITLE
feat(codeaction): add removeUnusedImports action

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ nmap <silent> gA <Plug>(coc-codeaction)
 - `Insert PHP Setter` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/33#issuecomment-1140684502)
 - `Insert PHP Getter & Setter` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/33#issuecomment-1140685034)
 - `Change Visibility` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/37#issue-1259334586)
+- `Remove all unused imports for "use" statetment` | [DEMO](https://github.com/yaegassy/coc-intelephense/pull/43#issue-1285689962)
 
 **Code Actions (Server side)**:
 

--- a/src/__tests__/removeUnusedImports.test.ts
+++ b/src/__tests__/removeUnusedImports.test.ts
@@ -1,0 +1,47 @@
+import { it, expect } from 'vitest';
+
+import * as removeUnusedImportsParser from '../parsers/removeUnusedImports';
+
+it('removeUnusedImports | with namespace', () => {
+  const contents: string[] = [];
+  contents.push(`<?php\n`);
+  contents.push(`\n`);
+  contents.push(`namespace Acme;\n`);
+  contents.push(`\n`);
+  contents.push(`use Acme\\ClassA;\n`);
+  contents.push(`use Acme\\ClassB as B;\n`);
+  contents.push(`use Acme\\Child\\{ClassC, ClassD as D};\n`);
+  contents.push(`use Acme\\Child\\GrandChild\\{\n`);
+  contents.push(`    ClassE,\n`);
+  contents.push(`    ClassF as F,\n`);
+  contents.push(`    ClassG,\n`);
+  contents.push(`};\n`);
+  contents.push(`use Acme\\Child\\GrandChild\\ClassH,\n`);
+  contents.push(`    Acme\\Child\\GrandChild\\ClassI as I,\n`);
+  contents.push(`    Acme\\Child\\GrandChild\\ClassJ;\n`);
+
+  const ast = removeUnusedImportsParser.getAst(contents.join('\n'));
+  const res = removeUnusedImportsParser.getUseNodes(ast.children);
+  expect(5).toBe(res.length);
+});
+
+it('removeUnusedImports | without namespace', () => {
+  const contents: string[] = [];
+  contents.push(`<?php\n`);
+  contents.push(`\n`);
+  contents.push(`use Acme\\ClassA;\n`);
+  contents.push(`use Acme\\ClassB as B;\n`);
+  contents.push(`use Acme\\Child\\{ClassC, ClassD as D};\n`);
+  contents.push(`use Acme\\Child\\GrandChild\\{\n`);
+  contents.push(`    ClassE,\n`);
+  contents.push(`    ClassF as F,\n`);
+  contents.push(`    ClassG,\n`);
+  contents.push(`};\n`);
+  contents.push(`use Acme\\Child\\GrandChild\\ClassH,\n`);
+  contents.push(`    Acme\\Child\\GrandChild\\ClassI as I,\n`);
+  contents.push(`    Acme\\Child\\GrandChild\\ClassJ;\n`);
+
+  const ast = removeUnusedImportsParser.getAst(contents.join('\n'));
+  const res = removeUnusedImportsParser.getUseNodes(ast.children);
+  expect(5).toBe(res.length);
+});

--- a/src/actions/removeUnusedImports.ts
+++ b/src/actions/removeUnusedImports.ts
@@ -1,0 +1,315 @@
+import {
+  CodeAction,
+  CodeActionContext,
+  CodeActionProvider,
+  Diagnostic,
+  Document,
+  DocumentSelector,
+  ExtensionContext,
+  languages,
+  Position,
+  Range,
+  TextDocument,
+  TextEdit,
+  workspace,
+} from 'coc.nvim';
+
+import * as removeUnusedImportsParser from '../parsers/removeUnusedImports';
+
+export function activate(context: ExtensionContext) {
+  const documentSelector: DocumentSelector = [{ language: 'php', scheme: 'file' }];
+
+  context.subscriptions.push(
+    languages.registerCodeActionProvider(documentSelector, new RemoveUnusedImportsCodeActionProvider(), 'intelephense')
+  );
+}
+
+type FeatureUseGroupItemType = {
+  // zero base range (location)
+  rangeStartLine: number;
+  rangeStartCharacter: number;
+  rangeEndLine: number;
+  rangeEndCharacter: number;
+  // real locaction
+  locStartLine: number;
+  locStartColumn: number;
+  locEndLine: number;
+  locEndColumn: number;
+  name: string | null;
+  type: string | null;
+  items: {
+    name: string;
+    aliasName: string | null;
+    locStartLine: number;
+    locStartColumn: number;
+    locEndLine: number;
+    locEndColumn: number;
+  }[];
+  diagSymbols: string[];
+};
+
+export class RemoveUnusedImportsCodeActionProvider implements CodeActionProvider {
+  public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext) {
+    const codeActions: CodeAction[] = [];
+    if (document.languageId !== 'php') return;
+    const doc = workspace.getDocument(document.uri);
+
+    if (this.wholeRange(doc, range) && context.diagnostics.length > 0) {
+      if (!this.isContainTargetCodeInDiagnostics(context.diagnostics, 1003)) return codeActions;
+
+      const ast = removeUnusedImportsParser.getAst(doc.getDocumentContent());
+      if (!ast) return codeActions;
+
+      const featureItems: FeatureUseGroupItemType[] = [];
+      const useNodes = removeUnusedImportsParser.getUseNodes(ast.children);
+
+      for (const u of useNodes) {
+        if (u.loc) {
+          if (u.loc.start && u.loc.end) {
+            for (const d of context.diagnostics) {
+              if (d.code && typeof d.code === 'number') {
+                if (d.code === 1003) {
+                  if (u.loc.start.line <= d.range.start.line + 1 && u.loc.end.line >= d.range.end.line + 1) {
+                    // WARNING: The key `item` of type `UseGroup.item` is actually `items`.
+                    const flatUseItems = removeUnusedImportsParser.flattenUseItems(u['items']);
+
+                    const diagSymbols: string[] = [];
+                    let diagSymbol: string | undefined;
+                    for (const useItem of flatUseItems) {
+                      if (
+                        d.range.start.line === useItem.locStartLine - 1 &&
+                        d.range.start.character === useItem.locStartColumn &&
+                        d.range.end.line === useItem.locEndLine - 1 &&
+                        d.range.end.character === useItem.locEndColumn
+                      ) {
+                        diagSymbol = useItem.name;
+                      }
+                    }
+
+                    if (diagSymbol) {
+                      diagSymbols.push(diagSymbol);
+                    }
+
+                    const item: FeatureUseGroupItemType = {
+                      name: u.name,
+                      type: u.type,
+                      rangeStartLine: d.range.start.line,
+                      rangeStartCharacter: d.range.start.character,
+                      rangeEndLine: d.range.end.line,
+                      rangeEndCharacter: d.range.end.character,
+                      locStartLine: u.loc.start.line,
+                      locStartColumn: u.loc.start.column,
+                      locEndLine: u.loc.end.line,
+                      locEndColumn: u.loc.end.column,
+                      items: flatUseItems,
+                      diagSymbols: diagSymbols,
+                    };
+
+                    let existsSameLocItem = false;
+                    featureItems.forEach((f) => {
+                      if (
+                        f.locStartLine === item.locStartLine &&
+                        f.locStartColumn === item.locStartColumn &&
+                        f.locEndLine === item.locEndLine &&
+                        f.locEndColumn === item.locEndColumn
+                      ) {
+                        existsSameLocItem = true;
+                        if (diagSymbol) f.diagSymbols.push(diagSymbol);
+                      }
+                    });
+
+                    if (!existsSameLocItem) {
+                      featureItems.push(item);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      const edits: TextEdit[] = [];
+      for (const f of featureItems) {
+        const edit = this.generateEdit(f, doc);
+        if (edit) {
+          edits.push(edit);
+        }
+      }
+
+      if (edits.length > 0) {
+        const action: CodeAction = {
+          title: `Remove all unused imports for "use" statetment`,
+          edit: {
+            changes: {
+              [doc.uri]: edits,
+            },
+          },
+        };
+
+        codeActions.push(action);
+      }
+    }
+
+    return codeActions;
+  }
+
+  private isContainTargetCodeInDiagnostics(diagnostics: Diagnostic[], code: number) {
+    for (const d of diagnostics) {
+      if (d.source === 'intelephense' && typeof d.code === 'number') {
+        if (d.code === code) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private generateEdit(item: FeatureUseGroupItemType, document: Document) {
+    let edit: TextEdit | undefined;
+    if (item.rangeStartLine === 0) return;
+
+    if (item.name === null && item.items.length === 1) {
+      // MEMO: "All unused"
+      //
+      // **Case**:
+      //
+      // ---
+      // use Acme\ClassA;
+      // use Acme\ClassB as B;
+      // ---
+
+      // If the target range of a line is deleted, a blank line is left.
+      // To delete a blank line itself, you must specify the tail range of the previous line.
+      const prevStartLine = item.rangeStartLine - 1;
+      const prevStartLineContent = document.getline(prevStartLine);
+      const prevStartEndColumn = prevStartLineContent.length;
+
+      edit = TextEdit.del(
+        Range.create(
+          Position.create(prevStartLine, prevStartEndColumn),
+          Position.create(item.rangeEndLine, item.rangeEndCharacter)
+        )
+      );
+    } else if (
+      (item.name !== null && item.items.length === item.diagSymbols.length) ||
+      (item.name === null && item.items.length > 1 && item.items.length === item.diagSymbols.length)
+    ) {
+      // MEMO: "All unused"
+      //
+      // **Case**:
+      //
+      // ---
+      // use Acme\Child\GrandChild\{
+      //     ClassE,
+      //     ClassF as F,
+      //     ClassG,
+      // };
+      // use Acme\Child\GrandChild\ClassH,
+      //     Acme\Child\GrandChild\ClassI as I,
+      //     Acme\Child\GrandChild\ClassJ;
+      // ---
+
+      // If the target range of a line is deleted, a blank line is left.
+      // To delete a blank line itself, you must specify the tail range of the previous line.
+      //
+      // Here we use the php-parser loc. php-parser loc is not zero base.
+      const prevStartLine = item.locStartLine - 2;
+      const prevStartLineContent = document.getline(prevStartLine);
+      const prevStartEndColumn = prevStartLineContent.length;
+
+      // The `php-parser` loc (location) is not a range including semicolons, etc.
+      // Here we use the php-parser loc. php-parser loc is not zero base.
+      const endLine = item.locEndLine - 1;
+      const endColmun = document.getline(endLine).length;
+
+      edit = TextEdit.del(
+        Range.create(Position.create(prevStartLine, prevStartEndColumn), Position.create(endLine, endColmun))
+      );
+    } else if (item.name === null && item.items.length > 1 && item.items.length !== item.diagSymbols.length) {
+      // MEMO: "Partially unused"
+      //
+      // **Case**:
+      //
+      // ---
+      // use Acme\Child\GrandChild\ClassH,
+      //     Acme\Child\GrandChild\ClassI as I,
+      //     Acme\Child\GrandChild\ClassJ;
+      // ---
+
+      const symbols: string[] = [];
+      item.items.forEach((i) => {
+        if (!item.diagSymbols.includes(i.name)) {
+          if (i.aliasName) {
+            symbols.push(`${i.name} as ${i.aliasName}`);
+          } else {
+            symbols.push(i.name);
+          }
+        }
+      });
+
+      const newTexts: string[] = [];
+      newTexts.push(`use ${symbols.join(', ')};`);
+
+      const startLine = item.locStartLine - 1;
+      const startColumn = item.locStartColumn;
+      const endLine = item.locEndLine - 1;
+      const endColmun = document.getline(endLine).length;
+
+      edit = TextEdit.replace(
+        Range.create(Position.create(startLine, startColumn), Position.create(endLine, endColmun)),
+        newTexts.join('')
+      );
+    } else if (item.name !== null && item.diagSymbols.length > 0 && item.items.length !== item.diagSymbols.length) {
+      // MEMO: "Partially unused"
+      //
+      // **Case**:
+      //
+      // ---
+      // use Acme\Child\GrandChild\{
+      //     ClassE,
+      //     ClassF as F,
+      //     ClassG,
+      // };
+      // ---
+
+      const symbols: string[] = [];
+      item.items.forEach((i) => {
+        if (!item.diagSymbols.includes(i.name)) {
+          if (i.aliasName) {
+            symbols.push(`${i.name} as ${i.aliasName}`);
+          } else {
+            symbols.push(i.name);
+          }
+        }
+      });
+
+      const newTexts: string[] = [];
+      newTexts.push(`use ${item.name}\\{${symbols.join(', ')}};`);
+
+      // The `php-parser` loc (location) is not a range including semicolons, etc.
+      // Here we use the php-parser loc. php-parser loc is not zero base.
+      const startLine = item.locStartLine - 1;
+      const startColumn = item.locStartColumn;
+      const endLine = item.locEndLine - 1;
+      const endColmun = document.getline(endLine).length;
+
+      edit = TextEdit.replace(
+        Range.create(Position.create(startLine, startColumn), Position.create(endLine, endColmun)),
+        newTexts.join('')
+      );
+    }
+
+    return edit;
+  }
+
+  private wholeRange(doc: Document, range: Range): boolean {
+    const whole = Range.create(0, 0, doc.lineCount, 0);
+    return (
+      whole.start.line === range.start.line &&
+      whole.start.character === range.start.character &&
+      whole.end.line === range.end.line &&
+      whole.end.character === whole.end.character
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import * as changeVisibilityCodeActionFeature from './actions/changeVisibility';
 import * as getterSetterCodeActionFeature from './actions/getterSetter';
 import * as ignoreCommentCodeActionFeature from './actions/ignoreComment';
 import * as openPHPNetCodeActionFeature from './actions/openPHPNet';
+import * as removeUnusedImportsCodeActionFeature from './actions/removeUnusedImports';
 import * as completeConstructorCommandFeature from './commands/completeConstructor';
 import * as composerCommandFeature from './commands/composer';
 import * as fixClassNameCommandFeature from './commands/fixClassName';
@@ -115,6 +116,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   openPHPNetCodeActionFeature.activate(context);
   ignoreCommentCodeActionFeature.activate(context);
   getterSetterCodeActionFeature.activate(context);
+  removeUnusedImportsCodeActionFeature.activate(context);
 
   // Add inlay hints by "client" side
   //

--- a/src/parsers/removeUnusedImports.ts
+++ b/src/parsers/removeUnusedImports.ts
@@ -1,0 +1,94 @@
+import { Engine, Namespace, Node, UseGroup, UseItem } from 'php-parser';
+
+const parserEngine = new Engine({
+  parser: {
+    extractDoc: true,
+    php7: true,
+    locations: true,
+    suppressErrors: true,
+  },
+  ast: {
+    all_tokens: true,
+    withPositions: true,
+  },
+});
+
+export function getAst(code: string) {
+  try {
+    return parserEngine.parseEval(stripPHPTag(code));
+  } catch (e) {
+    return undefined;
+  }
+
+  function stripPHPTag(code: string): string {
+    return code.replace('<?php', '').replace('?>', '');
+  }
+}
+
+export function getUseNodes(nodes: Node[], useGroupNodes: UseGroup[] = []) {
+  for (const node of nodes) {
+    if (node.kind === 'namespace') {
+      const namespaceNode = node as Namespace;
+      getUseNodes(namespaceNode.children, useGroupNodes);
+    }
+
+    if (node.kind === 'usegroup') {
+      const useGroupNode = node as UseGroup;
+      useGroupNodes.push(useGroupNode);
+    }
+  }
+
+  return useGroupNodes;
+}
+
+export function flattenUseItems(items: UseItem[]) {
+  //const flatItems: { name: string; aliasName: string | null }[] = [];
+  const flatItems: {
+    name: string;
+    aliasName: string | null;
+    locStartLine: number;
+    locStartColumn: number;
+    locEndLine: number;
+    locEndColumn: number;
+  }[] = [];
+
+  for (const item of items) {
+    const name = item.name;
+    let aliasName: string | null;
+    let locStartLine: number;
+    let locStartColumn: number;
+    let locEndLine: number;
+    let locEndColumn: number;
+
+    if (item.alias) {
+      aliasName = item.alias.name;
+    } else {
+      aliasName = null;
+    }
+
+    if (item.loc) {
+      locStartLine = item.loc.start.line;
+      locStartColumn = item.loc.start.column;
+      locEndLine = item.loc.end.line;
+      locEndColumn = item.loc.end.column;
+    } else {
+      locStartLine = 0;
+      locStartColumn = 0;
+      locEndLine = 0;
+      locEndColumn = 0;
+    }
+
+    const flatItem = {
+      name,
+      aliasName,
+      locStartLine,
+      locStartColumn,
+      locEndLine,
+      locEndColumn,
+    };
+
+    flatItems.push(flatItem);
+  }
+
+  return flatItems;
+}


### PR DESCRIPTION
## Description

Added code action to remove all unused imports in the "use" statement. It only works if `intelephense` is emitting a diagnostics message regarding the use statement.

If you need more features, such as sorting use statements, we recommend using a formatter like `php-cs-fixer`. An extension for "coc.nvim" is also available.

- **coc-php-cs-fixer**
  - <https://github.com/yaegassy/coc-php-cs-fixer>
  - `:CocInstall coc-php-cs-fixer`

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/175935031-8ff36f34-9621-4bc4-9a35-bca1190ff59a.mp4
