### PR TITLE
refactor(inlayHints): code changes for vim9 support

### DIFF
--- a/src/inlayHints/inlineParameters.ts
+++ b/src/inlayHints/inlineParameters.ts
@@ -110,11 +110,9 @@ class InlineParametersInlayHintsProvider implements InlayHintsProvider {
 
           if (!parameterName) continue;
 
-          const position = Position.create(parameter.end.line - 1, parameter.end.character);
+          const position = Position.create(parameter.start.line - 1, parameter.start.character);
 
-          if (index === 0) {
-            parameterName = ': ' + parameterName;
-          }
+          parameterName = parameterName + ':';
 
           const inlayHintLabelPart: InlayHintLabelPart[] = [
             {
@@ -132,6 +130,7 @@ class InlineParametersInlayHintsProvider implements InlayHintsProvider {
             position: position,
             tooltip: tooltipValue,
             paddingLeft: true,
+            paddingRight: true,
           };
 
           inlayHints.push(inlayHint);


### PR DESCRIPTION
`coc-intelephense` implements client-based inlayHints; since it only supports Neovim, it was implemented with only the assumption that they appear at the end of a line.

`coc.nvim` has added functionality to allow inlay hints to work with "vim9".

- <https://github.com/neoclide/coc.nvim/discussions/4095>
- <https://github.com/neoclide/coc.nvim/commit/d9967a047394e2365cb9e82b8dae494f9809241c>

Addjusted inlay hints for `coc-intelephense`.

