### PR TITLE
feat: add intelephense.{artisan,symfony}.withoutArgumentsCommandList setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ For more information, please check this link.
 - `intelephense.composer.runCommandList`: Set the subcommand of the composer you want to execute, default: `["dump-autoload", "clear-cache", "install", "update"]`
 - `intelephense.composer.runCommandPlusList`: Set the subcommand of the composer you want to execute. Additional strings can be entered and executed in the subcommand. default: `["require", "require --dev", "remove", "remove --dev", "update"]`
 - `intelephense.composer.enableSplitRight`: Use vertical belowright for composer terminal window, default: `false`
+- `intelephense.artisan.withoutArgumentsCommandList`: List of commands to quickly execute `intelephense.artisan.runCommand` or `intelephense.sailArtisan.runCommand` without prompting for arguments or options, e.g. `["route:list", "clear-compiled"]`, default: `[]`
 - `intelephense.artisan.enableSplitRight`: Use vertical belowright for artisan terminal window, default: `false`
+- `intelephense.symfony.withoutArgumentsCommandList`: List of commands to quickly execute `intelephense.symfony.runCommand` without prompting for arguments or options, default: `[]`
 - `intelephense.symfony.enableSplitRight`: Use vertical belowright for symfony terminal window, default: `false`
 - `intelephense.phpunit.path`: Path to phpunit command. If there is no setting, the vendor/bin/phpunit will be used, default: `""`
 - `intelephense.phpunit.colors`: Use colors in output (--colors), default: `false`

--- a/package.json
+++ b/package.json
@@ -170,10 +170,20 @@
           "default": false,
           "description": "Use vertical belowright for composer terminal window."
         },
+        "intelephense.artisan.withoutArgumentsCommandList": {
+          "type": "array",
+          "default": [],
+          "description": "List of commands to quickly execute `intelephense.artisan.runCommand` or `intelephense.sailArtisan.runCommand` without prompting for arguments or options, e.g. `[\"route:list\", \"clear-compiled\"]`."
+        },
         "intelephense.artisan.enableSplitRight": {
           "type": "boolean",
           "default": false,
           "description": "Use vertical belowright for artisan terminal window."
+        },
+        "intelephense.symfony.withoutArgumentsCommandList": {
+          "type": "array",
+          "default": [],
+          "description": "List of commands to quickly execute `intelephense.symfony.runCommand` without prompting for arguments or options."
         },
         "intelephense.symfony.enableSplitRight": {
           "type": "boolean",

--- a/src/commands/symfonyConsole.ts
+++ b/src/commands/symfonyConsole.ts
@@ -99,13 +99,30 @@ async function runSymfonyConsole(commandName: string, entryPoint: string, baseCo
     return;
   }
 
+  const artisanWithoutArgumentsCommandList = workspace
+    .getConfiguration('intelephense')
+    .get<string[]>('artisan.withoutArgumentsCommandList', []);
+
+  const symfonyWithoutArgumentsCommandList = workspace
+    .getConfiguration('intelephense')
+    .get<string[]>('symfony.withoutArgumentsCommandList', []);
+
+  const withoutArgumentsCommandList: string[] = [];
+  if (entryPoint === 'artisan' || entryPoint === 'sail') {
+    withoutArgumentsCommandList.push(...artisanWithoutArgumentsCommandList);
+  } else if (entryPoint === 'bin/console') {
+    withoutArgumentsCommandList.push(...symfonyWithoutArgumentsCommandList);
+  }
+
   let input = '';
-  const isInput = await window.showPrompt(`"${commandName}" | Add args & options?`);
-  if (isInput) {
-    input = await window.requestInput(`${commandName}`);
-    if (!input) {
-      const isExec = await window.showPrompt(`Input is empty, can I run it?`);
-      if (!isExec) return;
+  if (!withoutArgumentsCommandList.includes(commandName)) {
+    const isInput = await window.showPrompt(`"${commandName}" | Add args & options?`);
+    if (isInput) {
+      input = await window.requestInput(`${commandName}`);
+      if (!input) {
+        const isExec = await window.showPrompt(`Input is empty, can I run it?`);
+        if (!isExec) return;
+      }
     }
   }
 


### PR DESCRIPTION
## Add configuration

- `intelephense.artisan.withoutArgumentsCommandList`
    - List of commands to quickly execute `intelephense.artisan.runCommand` or `intelephense.sailArtisan.runCommand` without prompting for arguments or options, e.g. `["route:list", "clear-compiled"]`, default: `[]`
- `intelephense.symfony.withoutArgumentsCommandList`
    - List of commands to quickly execute `intelephense.symfony.runCommand` without prompting for arguments or options, default: `[]`
